### PR TITLE
Add @kentico/sourcebit-source-kontent plugin.

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -18,6 +18,12 @@
     "type": "source"
   },
   {
+    "module": "@kentico/sourcebit-source-kontent",
+    "description": "A Kontent source plugin for Sourcebit",
+    "author": "Kentico",
+    "type": "source"
+  },
+  {
     "module": "sourcebit-target-jekyll",
     "description": "A Sourcebit plugin for Jekyll",
     "author": "Stackbit",


### PR DESCRIPTION
Add the Sourcebit source plugin for Kentico Kontent headless CMS.